### PR TITLE
fix: removing `bucket_acls`

### DIFF
--- a/terraform/modules/tenant-apps/main.tf
+++ b/terraform/modules/tenant-apps/main.tf
@@ -14,11 +14,6 @@ resource "aws_s3_bucket" "producer_bucket" {
   }
 }
 
-resource "aws_s3_bucket_acl" "producer" {
-  bucket = aws_s3_bucket.producer_bucket[0].id
-}
-
-
 # CONSUMER INFRAESTRUCTURE
 resource "aws_s3_bucket" "consumer_bucket" {
   count  = var.enable_consumer == true ? 1 : 0
@@ -29,11 +24,6 @@ resource "aws_s3_bucket" "consumer_bucket" {
   }
 }
 
-resource "aws_s3_bucket_acl" "consumer" {
-  bucket = aws_s3_bucket.consumer_bucket[0].id
-}
-
-
 # PAYMENTS INFRAESTRUCTURE
 # resource "aws_s3_bucket" "payments_bucket" {
 #   count  = var.enable_payments == true ? 1 : 0
@@ -42,8 +32,4 @@ resource "aws_s3_bucket_acl" "consumer" {
 #   tags = {
 #     Name = var.tenant_id
 #   }
-# }
-
-# resource "aws_s3_bucket_acl" "payments" {
-#   bucket = aws_s3_bucket.payments_bucket[0].id
 # }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Remove `bucket_acls` resources that were causing 

```
api error AccessControlListNotSupported: The bucket does not allow ACLs
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
