### PR TITLE
fixes to cleanup and install scripts

### DIFF
--- a/cleanup.sh
+++ b/cleanup.sh
@@ -10,6 +10,15 @@ CONSUMERSERVICEECR="consumer-container"
 PRODUCERSERVICEECR="producer-container"
 VPC_NAME="eks-saas-gitops"
 
+#set terraform folders (weather they have been copied to code-commit folder or not)
+if [ ! -d "$APPLICATION_PLANE_INFRA_FOLDER" ]; then
+     APPLICATION_PLANE_INFRA_FOLDER="/home/ec2-user/environment/eks-saas-gitops/terraform/application-plane/production/environments"
+fi
+
+if [ ! -d "$TERRAFORM_CLUSTER_FOLDER" ]; then
+     TERRAFORM_CLUSTER_FOLDER="/home/ec2-user/environment/eks-saas-gitops/terraform/clusters/production"
+fi
+
 #delete code-commit user ssh key
 user_info=$(aws iam list-ssh-public-keys --user-name "$IAM_USER_NAME" )
 key_ids=$(echo "$user_info" | jq -r '.SSHPublicKeys[]?.SSHPublicKeyId')

--- a/helpers/cloudformation.yaml
+++ b/helpers/cloudformation.yaml
@@ -261,7 +261,7 @@ Resources:
                       )
                       logger.info('SSM parameter eks-saas-gitops-custom-resource-event set - running cleanup.sh')
                       
-                      run_ssm_command('root', instance['InstanceId'], 'cd /home/ec2-user/environment && ./cleanup.sh', 'cleanupoutput')
+                      run_ssm_command('ec2-user', instance['InstanceId'], 'cd /home/ec2-user/environment && ./cleanup.sh', 'cleanupoutput')
 
                   if event['RequestType'] == 'Create':                                  
                       ec2 = boto3.client('ec2')

--- a/helpers/cloudformation.yaml
+++ b/helpers/cloudformation.yaml
@@ -261,7 +261,7 @@ Resources:
                       )
                       logger.info('SSM parameter eks-saas-gitops-custom-resource-event set - running cleanup.sh')
                       
-                      run_ssm_command('ec2-user', instance['InstanceId'], 'cd /home/ec2-user/environment/eks-saas-gitops-aws && chmod +x cleanup.sh && ./cleanup.sh', 'cleanupoutput')
+                      run_ssm_command('ec2-user', instance['InstanceId'], 'cd /home/ec2-user/environment && chmod +x cleanup.sh && ./cleanup.sh', 'cleanupoutput')
 
                   if event['RequestType'] == 'Create':                                  
                       ec2 = boto3.client('ec2')
@@ -419,6 +419,7 @@ Resources:
             - echo '====== Provision Terraform ======'
             - git clone https://github.com/aws-samples/eks-saas-gitops.git /home/ec2-user/environment/eks-saas-gitops
             - cp /home/ec2-user/environment/eks-saas-gitops/install.sh /home/ec2-user/environment/install.sh && chmod +x /home/ec2-user/environment/install.sh
+            - cp /home/ec2-user/environment/eks-saas-gitops/cleanup.sh /home/ec2-user/environment/cleanup.sh && chmod +x /home/ec2-user/environment/cleanup.sh
             - /home/ec2-user/environment/install.sh
             - echo "Bootstrap completed with return code $?"
             - shutdown -r +1

--- a/helpers/cloudformation.yaml
+++ b/helpers/cloudformation.yaml
@@ -261,7 +261,7 @@ Resources:
                       )
                       logger.info('SSM parameter eks-saas-gitops-custom-resource-event set - running cleanup.sh')
                       
-                      run_ssm_command('ec2-user', instance['InstanceId'], 'cd /home/ec2-user/environment && chmod +x cleanup.sh && ./cleanup.sh', 'cleanupoutput')
+                      run_ssm_command('root', instance['InstanceId'], 'cd /home/ec2-user/environment && ./cleanup.sh', 'cleanupoutput')
 
                   if event['RequestType'] == 'Create':                                  
                       ec2 = boto3.client('ec2')

--- a/install.sh
+++ b/install.sh
@@ -15,7 +15,7 @@ catch_error() {
 
      JSON_DATA='{
           "Status": "'"$STATUS"'",
-          "Reason": "Error "'"$1"'" occurred on "'"$2"'",
+          "Reason": "Error '"$1"' occurred on '"$2"'",
           "StackId": "'"$EVENT_STACK_ID"'",
           "PhysicalResourceId": "Terraform",
           "RequestId": "'"$EVENT_REQUEST_ID"'",


### PR DESCRIPTION
*Issue #, if available:*
fix to cleanup script when deploy is aborted mid deployment 
fix CFN error feedback from install.sh

*Description of changes:*
- cleanup checks for cloud9 filesystem folders before trying to destroy terraform
- cleanup file is copied during install and executed from /home/ec2-user/environment
- Install.sh CFN feedback during error handling fix 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
